### PR TITLE
Updates to all_tests_have_result?

### DIFF
--- a/spec/runscope_ci_spec.rb
+++ b/spec/runscope_ci_spec.rb
@@ -102,7 +102,7 @@ describe RunscopeCi do
         let(:extracted_tests) { [passed_test_1, passed_test_2, failed_test_1] }
 
         context "and we expected all to pass" do
-          it { is_expected.to eql([false, extracted_tests]) }
+          it { expect{subject}.to raise_error(RuntimeError, "Unexpected test results") }
         end
       end
 
@@ -110,13 +110,13 @@ describe RunscopeCi do
         let(:extracted_tests) { [passed_test_1, passed_test_2] }
 
         context "and we expected all to pass" do
-          it { is_expected.to eql([true, extracted_tests]) }
+          it { is_expected.to eql("Tests finished working. Success! All results were: pass") }
         end
 
         context "and we expected all to fail" do
           let(:expected_result) { "fail" }
 
-          it { is_expected.to eql([false, extracted_tests]) }
+          it { expect{subject}.to raise_error(RuntimeError, "Unexpected test results") }
         end
       end
 
@@ -126,11 +126,11 @@ describe RunscopeCi do
         context "and we expected all to fail" do
           let(:expected_result) { "fail" }
 
-          it { is_expected.to eql([true, extracted_tests]) }
+          it { is_expected.to eql("Tests finished working. Success! All results were: fail") }
         end
 
         context "and we expected all to pass" do
-          it { is_expected.to eql([false, extracted_tests]) }
+          it { expect{subject}.to raise_error(RuntimeError, "Unexpected test results") }
         end
       end
     end


### PR DESCRIPTION
**all_tests_have_result?** will now `raise` exception when test results do not all match expected result via **trigger_bucket_and_poll_results**. If all successful, **all_tests_have_result?** will `return` success message. 

example output for failure: 

<img width="916" alt="screen shot 2018-03-26 at 8 07 54 am" src="https://user-images.githubusercontent.com/1334704/37914775-d74c7a5c-30cc-11e8-9db8-c6087c5efab9.png">

In the case of unexpected results, users are shown each respective runscope test's name, result status, and url.